### PR TITLE
Return Success None if indicator is outside of data buffer?

### DIFF
--- a/src/statement/output.rs
+++ b/src/statement/output.rs
@@ -66,9 +66,13 @@ impl<'p> Raii<'p, ffi::Stmt> {
                 if indicator == ffi::SQL_NULL_DATA {
                     Return::Success(None)
                 } else {
-                    assert!(start_pos + indicator as usize <= buffer.len(), "no more data but indicatior outside of data buffer");
-                    let slice = &buffer[..(start_pos + indicator as usize)];
-                    Return::Success(Some(T::convert(slice)))
+                    if start_pos + indicator as usize <= buffer.len() {
+                        Return::Success(None)
+                    }
+                    else {
+                        let slice = &buffer[..(start_pos + indicator as usize)];
+                        Return::Success(Some(T::convert(slice)))
+                    }
                 }
             }
             ffi::SQL_SUCCESS_WITH_INFO => {


### PR DESCRIPTION
I'm not sure if this fixes any problems - and I did not test it. Just trying to illustrate what I think might be the problem. 

Please review Issue: https://github.com/ibmdb/rust-ibm_db/issues/4