### PR TITLE
If indicator is outside of data buffer -> return None()

### DIFF
--- a/src/statement/output.rs
+++ b/src/statement/output.rs
@@ -66,9 +66,13 @@ impl<'p> Raii<'p, ffi::Stmt> {
                 if indicator == ffi::SQL_NULL_DATA {
                     Return::Success(None)
                 } else {
-                    assert!(start_pos + indicator as usize <= buffer.len(), "no more data but indicatior outside of data buffer");
-                    let slice = &buffer[..(start_pos + indicator as usize)];
-                    Return::Success(Some(T::convert(slice)))
+                    if start_pos + indicator as usize <= buffer.len() {
+                        Return::Success(None)
+                    }
+                    else {
+                        let slice = &buffer[..(start_pos + indicator as usize)];
+                        Return::Success(Some(T::convert(slice)))
+                    }
                 }
             }
             ffi::SQL_SUCCESS_WITH_INFO => {

--- a/src/statement/output.rs
+++ b/src/statement/output.rs
@@ -66,7 +66,7 @@ impl<'p> Raii<'p, ffi::Stmt> {
                 if indicator == ffi::SQL_NULL_DATA {
                     Return::Success(None)
                 } else {
-                    if start_pos + indicator as usize <= buffer.len() {
+                    if start_pos + indicator as usize >= buffer.len() {
                         Return::Success(None)
                     }
                     else {


### PR DESCRIPTION
I can confirm that in my testing this fixes
Issue: ibmdb#4